### PR TITLE
put superagent into dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
     "eslint": "^2.7.0",
-    "eslint-plugin-babel": "^3.1.0",
-    "superagent": "^1.8.3"
+    "eslint-plugin-babel": "^3.1.0"
   },
   "dependencies": {
     "body-parser": "^1.15.0",
     "cors": "^2.7.1",
     "express": "^4.13.4",
-    "socket.io": "^1.4.5"
+    "socket.io": "^1.4.5",
+    "superagent": "^1.8.3"
   }
 }


### PR DESCRIPTION
I was hitting module missing error, and it was that the superagent module is put under devDependencies, which will not be installed from the npm install command. So I just put it under dependencies or maybe providing a bundled dist file will do the work.